### PR TITLE
docs: enrich CLAUDE.md with Go rules from PR reviews

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,11 @@ Repository: `https://github.com/flemzord/sclaw`
 ```
 cmd/sclaw/main.go   → Entry point
 internal/           → Private packages (not importable)
+  internal/config/  → Configuration loading and validation
+  internal/core/    → Module system and registry
+  internal/provider/→ Provider interface, failover chain, health tracking
 pkg/                → Public reusable packages
+  pkg/message/      → Platform-agnostic message model
 docs/               → Additional documentation
 ```
 
@@ -43,6 +47,36 @@ test    # Run tests with race detector + coverage
 - **Formatting**: gofumpt (enforced by golangci-lint)
 - **Project layout**: Follow standard Go project layout (cmd/, internal/, pkg/)
 - **Commits**: Conventional Commits (`feat:`, `fix:`, `chore:`, `ci:`, `docs:`)
+
+## Go Rules (from PR reviews)
+
+### Function Design
+
+- **Use request structs for 4+ parameters**: When a function takes more than 3 parameters (excluding `ctx`), group them into a dedicated request/options struct. This improves readability and makes future extensions backward-compatible.
+- **Return errors, never panic**: Always return `error` for conditions that depend on caller input. Reserve `panic` only for true programming errors (violated invariants that should never happen). User-provided config should never cause a panic.
+
+### Data & Performance
+
+- **Prefer O(1) lookups**: Normalize data at the source (e.g., trim map keys during validation) so that resolution functions can use direct map lookups instead of iterating.
+- **Pass large structs by pointer**: Types like `yaml.Node` that contain subtrees should be passed as `*yaml.Node` to avoid unnecessary copying.
+- **Nil slices over empty slices**: Prefer `var candidates []string` over `candidates := []string{}`. Nil slices are more idiomatic in Go and work the same with `append`.
+
+### Concurrency
+
+- **Encapsulate channels behind methods**: Never export raw channels. Expose a method with state validation (e.g., `Respond()` that checks if an approval is pending) to prevent misuse of concurrent primitives.
+- **Defer health verdicts**: When tracking provider health, record success only after the full operation completes (including stream consumption), not just at connection time. Mid-stream errors must degrade health.
+
+### Code Quality
+
+- **DRY — Extract duplicated logic**: When the same block of code (5+ lines) appears in multiple branches, extract it into a private method.
+- **Avoid mutating value copies**: When you need to read a field with a default, use a pure reader method with a value receiver (e.g., `checkIntervalOrDefault()`) instead of calling a mutating method on a copy.
+- **Use modern Go idioms**: Prefer `slices.Sort` over `sort.Strings`, `slices.Contains` over custom `inList()` helpers, and `os.LookupEnv` over `os.Getenv` when you need to distinguish empty from unset.
+- **Document design decisions**: When a design choice might surprise a reader (e.g., scopes validated at registration but not enforced at execution), add a comment explaining the intent and where the responsibility lies.
+
+### Testing
+
+- **Never export test helpers in production packages**: Use unexported functions with `_test` build tags, or place helpers in a dedicated `<package>test/` sub-package (e.g., `providertest/`).
+- **Clean up provisioned resources**: If a module acquires resources during provisioning (DB connections, files, goroutines), ensure there is a cleanup path. Test teardown must not leak.
 
 ## CI/CD
 


### PR DESCRIPTION
## Summary

- Extracted recurring code review patterns from PRs #18, #19, #20, and #21 into a new **Go Rules** section in CLAUDE.md (via AGENTS.md symlink)
- Rules cover: function design, data/performance, concurrency, code quality, and testing
- Updated architecture section with new packages (`internal/config`, `internal/core`, `internal/provider`, `pkg/message`)

## Rules added

| Category | Rules |
|---|---|
| **Function Design** | Request structs for 4+ params, return errors instead of panic |
| **Data & Performance** | O(1) lookups, pass large structs by pointer, nil slices |
| **Concurrency** | Encapsulate channels behind methods, defer health verdicts |
| **Code Quality** | DRY extraction, avoid mutating copies, modern Go idioms, document design decisions |
| **Testing** | No exported test helpers in prod, clean up provisioned resources |

## Source PRs analyzed

- #18 — feat: add module system and config system
- #19 — feat: add platform-agnostic message model
- #20 — feat: add provider interface and failover chain
- #21 — feat: implement tool approvals and registry execution