### PR TITLE
feat: implement agent ReAct reasoning loop (Phase 6)

### DIFF
--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -1,0 +1,42 @@
+package agent
+
+import "time"
+
+// Default values for LoopConfig.
+const (
+	DefaultMaxIterations = 10
+	DefaultTokenBudget   = 0 // 0 means unlimited.
+	DefaultTimeout       = 5 * time.Minute
+	DefaultLoopThreshold = 3
+)
+
+// LoopConfig controls the behavior of the agent reasoning loop.
+type LoopConfig struct {
+	// MaxIterations is the maximum number of reason-act cycles.
+	MaxIterations int
+
+	// TokenBudget is the cumulative token limit (input + output).
+	// Zero means unlimited.
+	TokenBudget int
+
+	// Timeout is the maximum wall-clock duration for the loop.
+	Timeout time.Duration
+
+	// LoopThreshold is how many times the same tool call (name + args)
+	// can repeat before the loop is considered stuck.
+	LoopThreshold int
+}
+
+// withDefaults returns a copy with zero fields replaced by defaults.
+func (c LoopConfig) withDefaults() LoopConfig {
+	if c.MaxIterations <= 0 {
+		c.MaxIterations = DefaultMaxIterations
+	}
+	if c.Timeout <= 0 {
+		c.Timeout = DefaultTimeout
+	}
+	if c.LoopThreshold <= 0 {
+		c.LoopThreshold = DefaultLoopThreshold
+	}
+	return c
+}

--- a/internal/agent/config_test.go
+++ b/internal/agent/config_test.go
@@ -1,0 +1,62 @@
+package agent
+
+import (
+	"testing"
+	"time"
+)
+
+func TestWithDefaults_ZeroValue(t *testing.T) {
+	t.Parallel()
+
+	cfg := LoopConfig{}.withDefaults()
+
+	if cfg.MaxIterations != DefaultMaxIterations {
+		t.Errorf("MaxIterations = %d, want %d", cfg.MaxIterations, DefaultMaxIterations)
+	}
+	if cfg.Timeout != DefaultTimeout {
+		t.Errorf("Timeout = %v, want %v", cfg.Timeout, DefaultTimeout)
+	}
+	if cfg.LoopThreshold != DefaultLoopThreshold {
+		t.Errorf("LoopThreshold = %d, want %d", cfg.LoopThreshold, DefaultLoopThreshold)
+	}
+	if cfg.TokenBudget != 0 {
+		t.Errorf("TokenBudget = %d, want 0 (unlimited)", cfg.TokenBudget)
+	}
+}
+
+func TestWithDefaults_ExplicitValues(t *testing.T) {
+	t.Parallel()
+
+	cfg := LoopConfig{
+		MaxIterations: 20,
+		TokenBudget:   5000,
+		Timeout:       10 * time.Minute,
+		LoopThreshold: 5,
+	}.withDefaults()
+
+	if cfg.MaxIterations != 20 {
+		t.Errorf("MaxIterations = %d, want 20", cfg.MaxIterations)
+	}
+	if cfg.TokenBudget != 5000 {
+		t.Errorf("TokenBudget = %d, want 5000", cfg.TokenBudget)
+	}
+	if cfg.Timeout != 10*time.Minute {
+		t.Errorf("Timeout = %v, want 10m", cfg.Timeout)
+	}
+	if cfg.LoopThreshold != 5 {
+		t.Errorf("LoopThreshold = %d, want 5", cfg.LoopThreshold)
+	}
+}
+
+func TestWithDefaults_ZeroBudgetStaysUnlimited(t *testing.T) {
+	t.Parallel()
+
+	cfg := LoopConfig{
+		MaxIterations: 5,
+		TokenBudget:   0,
+	}.withDefaults()
+
+	if cfg.TokenBudget != 0 {
+		t.Errorf("TokenBudget = %d, want 0 (unlimited)", cfg.TokenBudget)
+	}
+}

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -1,0 +1,105 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/flemzord/sclaw/internal/provider"
+	"github.com/flemzord/sclaw/internal/tool"
+)
+
+// ToolExecutorConfig holds the dependencies for tool execution.
+type ToolExecutorConfig struct {
+	Registry        *tool.Registry
+	PolicyCfg       tool.PolicyConfig
+	PolicyCtx       tool.PolicyContext
+	Elevated        *tool.ElevatedState
+	Requester       tool.ApprovalRequester
+	ApprovalTimeout time.Duration
+	Env             tool.ExecutionEnv
+}
+
+// ToolExecutor handles parallel tool execution with panic recovery.
+type ToolExecutor struct {
+	registry        *tool.Registry
+	policyCfg       tool.PolicyConfig
+	policyCtx       tool.PolicyContext
+	elevated        *tool.ElevatedState
+	requester       tool.ApprovalRequester
+	approvalTimeout time.Duration
+	env             tool.ExecutionEnv
+}
+
+// NewToolExecutor creates a ToolExecutor from the given configuration.
+func NewToolExecutor(cfg ToolExecutorConfig) *ToolExecutor {
+	return &ToolExecutor{
+		registry:        cfg.Registry,
+		policyCfg:       cfg.PolicyCfg,
+		policyCtx:       cfg.PolicyCtx,
+		elevated:        cfg.Elevated,
+		requester:       cfg.Requester,
+		approvalTimeout: cfg.ApprovalTimeout,
+		env:             cfg.Env,
+	}
+}
+
+// Execute runs all tool calls in parallel and returns results in input order.
+// Panics in individual tools are recovered and reported as error outputs.
+func (e *ToolExecutor) Execute(ctx context.Context, calls []provider.ToolCall) []ToolCallRecord {
+	results := make([]ToolCallRecord, len(calls))
+	var wg sync.WaitGroup
+
+	for i, call := range calls {
+		wg.Add(1)
+		go func(idx int, tc provider.ToolCall) {
+			defer wg.Done()
+			results[idx] = e.executeSingle(ctx, tc)
+		}(i, call)
+	}
+
+	wg.Wait()
+	return results
+}
+
+func (e *ToolExecutor) executeSingle(ctx context.Context, tc provider.ToolCall) (record ToolCallRecord) {
+	record.ID = tc.ID
+	record.Name = tc.Name
+	record.Arguments = tc.Arguments
+
+	start := time.Now()
+
+	defer func() {
+		record.Duration = time.Since(start)
+		if r := recover(); r != nil {
+			record.Panicked = true
+			record.Output = tool.Output{
+				Content: fmt.Sprintf("panic: %v", r),
+				IsError: true,
+			}
+		}
+	}()
+
+	out, err := e.registry.Execute(
+		ctx,
+		tc.Name,
+		tc.Arguments,
+		e.policyCfg,
+		e.policyCtx,
+		e.elevated,
+		e.requester,
+		e.approvalTimeout,
+		e.env,
+	)
+	if err != nil {
+		record.Output = tool.Output{
+			Content: err.Error(),
+			IsError: true,
+		}
+		return record
+	}
+
+	record.Output = out
+	return record
+}

--- a/internal/agent/executor_test.go
+++ b/internal/agent/executor_test.go
@@ -1,0 +1,269 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/flemzord/sclaw/internal/provider"
+	"github.com/flemzord/sclaw/internal/tool"
+)
+
+// mockTool implements tool.Tool for testing across the agent package.
+// It supports configurable output, errors, panics, and execution delay.
+type mockTool struct {
+	name      string
+	output    tool.Output
+	err       error
+	panicMsg  string
+	execDelay time.Duration
+}
+
+func (m *mockTool) Name() string                      { return m.name }
+func (m *mockTool) Description() string               { return "mock tool" }
+func (m *mockTool) Schema() json.RawMessage           { return json.RawMessage(`{}`) }
+func (m *mockTool) Scopes() []tool.Scope              { return []tool.Scope{tool.ScopeReadOnly} }
+func (m *mockTool) DefaultPolicy() tool.ApprovalLevel { return tool.ApprovalAllow }
+
+func (m *mockTool) Execute(_ context.Context, _ json.RawMessage, _ tool.ExecutionEnv) (tool.Output, error) {
+	if m.execDelay > 0 {
+		time.Sleep(m.execDelay)
+	}
+	if m.panicMsg != "" {
+		panic(m.panicMsg)
+	}
+	return m.output, m.err
+}
+
+func newTestExecutor(reg *tool.Registry) *ToolExecutor {
+	return NewToolExecutor(ToolExecutorConfig{
+		Registry: reg,
+		PolicyCfg: tool.PolicyConfig{
+			DM: tool.Policy{Default: tool.ApprovalAllow},
+		},
+		PolicyCtx: tool.PolicyContextDM,
+	})
+}
+
+func newTestExecutorFromTools(tools ...*mockTool) *ToolExecutor {
+	reg := tool.NewRegistry()
+	for _, t := range tools {
+		if err := reg.Register(t); err != nil {
+			panic(err)
+		}
+	}
+	return newTestExecutor(reg)
+}
+
+func tc(id, name string) provider.ToolCall {
+	return provider.ToolCall{
+		ID:        id,
+		Name:      name,
+		Arguments: json.RawMessage(`{}`),
+	}
+}
+
+func TestExecute_SingleSuccess(t *testing.T) {
+	t.Parallel()
+
+	mt := &mockTool{
+		name:   "echo",
+		output: tool.Output{Content: "hello", IsError: false},
+	}
+	exec := newTestExecutorFromTools(mt)
+	results := exec.Execute(context.Background(), []provider.ToolCall{tc("c1", "echo")})
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if r.ID != "c1" {
+		t.Errorf("ID = %q, want c1", r.ID)
+	}
+	if r.Output.Content != "hello" {
+		t.Errorf("Content = %q, want hello", r.Output.Content)
+	}
+	if r.Output.IsError {
+		t.Error("expected no error")
+	}
+	if r.Panicked {
+		t.Error("expected no panic")
+	}
+}
+
+func TestExecute_ParallelExecution(t *testing.T) {
+	t.Parallel()
+
+	delay := 100 * time.Millisecond
+	tools := []*mockTool{
+		{name: "tool1", output: tool.Output{Content: "tool1"}, execDelay: delay},
+		{name: "tool2", output: tool.Output{Content: "tool2"}, execDelay: delay},
+		{name: "tool3", output: tool.Output{Content: "tool3"}, execDelay: delay},
+	}
+	exec := newTestExecutorFromTools(tools...)
+
+	start := time.Now()
+	results := exec.Execute(context.Background(), []provider.ToolCall{
+		tc("c1", "tool1"),
+		tc("c2", "tool2"),
+		tc("c3", "tool3"),
+	})
+	elapsed := time.Since(start)
+
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+	// Sequential would take 3*delay; parallel should take roughly 1*delay.
+	maxExpected := 2 * delay
+	if elapsed > maxExpected {
+		t.Errorf("elapsed %v suggests sequential execution (want < %v)", elapsed, maxExpected)
+	}
+}
+
+func TestExecute_PanicRecovery(t *testing.T) {
+	t.Parallel()
+
+	mt := &mockTool{
+		name:     "panicker",
+		panicMsg: "something went wrong",
+	}
+	exec := newTestExecutorFromTools(mt)
+	results := exec.Execute(context.Background(), []provider.ToolCall{tc("c1", "panicker")})
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if !r.Panicked {
+		t.Error("expected Panicked=true")
+	}
+	if !r.Output.IsError {
+		t.Error("expected IsError=true after panic")
+	}
+	if r.Output.Content == "" {
+		t.Error("expected non-empty Content after panic")
+	}
+}
+
+func TestExecute_ToolError(t *testing.T) {
+	t.Parallel()
+
+	mt := &mockTool{
+		name: "failer",
+		err:  errors.New("execution failed"),
+	}
+	exec := newTestExecutorFromTools(mt)
+	results := exec.Execute(context.Background(), []provider.ToolCall{tc("c1", "failer")})
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if !r.Output.IsError {
+		t.Error("expected IsError=true")
+	}
+	if r.Output.Content != "execution failed" {
+		t.Errorf("Content = %q, want %q", r.Output.Content, "execution failed")
+	}
+	if r.Panicked {
+		t.Error("expected Panicked=false for normal error")
+	}
+}
+
+func TestExecute_ToolNotFound(t *testing.T) {
+	t.Parallel()
+
+	reg := tool.NewRegistry()
+	exec := newTestExecutor(reg)
+	results := exec.Execute(context.Background(), []provider.ToolCall{tc("c1", "nonexistent")})
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if !r.Output.IsError {
+		t.Error("expected IsError=true for missing tool")
+	}
+	if r.Output.Content == "" {
+		t.Error("expected non-empty error content")
+	}
+}
+
+func TestExecute_MaintainsOrder(t *testing.T) {
+	t.Parallel()
+
+	names := []string{"alpha", "beta", "gamma", "delta"}
+	tools := make([]*mockTool, 0, len(names))
+	for i, name := range names {
+		// Tools with longer delays registered first finish last — verifies order is preserved.
+		delay := time.Duration(len(names)-i) * 10 * time.Millisecond
+		tools = append(tools, &mockTool{
+			name:      name,
+			output:    tool.Output{Content: name},
+			execDelay: delay,
+		})
+	}
+	exec := newTestExecutorFromTools(tools...)
+
+	calls := make([]provider.ToolCall, len(names))
+	for i, name := range names {
+		calls[i] = tc(name+"-id", name)
+	}
+
+	results := exec.Execute(context.Background(), calls)
+
+	if len(results) != len(names) {
+		t.Fatalf("expected %d results, got %d", len(names), len(results))
+	}
+	for i, name := range names {
+		if results[i].Name != name {
+			t.Errorf("results[%d].Name = %q, want %q", i, results[i].Name, name)
+		}
+		if results[i].Output.Content != name {
+			t.Errorf("results[%d].Content = %q, want %q", i, results[i].Output.Content, name)
+		}
+	}
+}
+
+// TestExecute_ParallelErrorIsolation verifies that one tool erroring/panicking
+// does not block or affect the results of other parallel tools.
+func TestExecute_ParallelErrorIsolation(t *testing.T) {
+	t.Parallel()
+
+	tools := []*mockTool{
+		{name: "good1", output: tool.Output{Content: "ok1"}},
+		{name: "panicker", panicMsg: "boom"},
+		{name: "good2", output: tool.Output{Content: "ok2"}},
+	}
+	exec := newTestExecutorFromTools(tools...)
+
+	results := exec.Execute(context.Background(), []provider.ToolCall{
+		tc("c1", "good1"),
+		tc("c2", "panicker"),
+		tc("c3", "good2"),
+	})
+
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+
+	// good1 succeeded.
+	if results[0].Output.IsError || results[0].Output.Content != "ok1" {
+		t.Errorf("results[0]: expected success with 'ok1', got error=%v content=%q",
+			results[0].Output.IsError, results[0].Output.Content)
+	}
+
+	// panicker failed.
+	if !results[1].Panicked || !results[1].Output.IsError {
+		t.Errorf("results[1]: expected panic, got panicked=%v error=%v",
+			results[1].Panicked, results[1].Output.IsError)
+	}
+
+	// good2 succeeded despite panicker.
+	if results[2].Output.IsError || results[2].Output.Content != "ok2" {
+		t.Errorf("results[2]: expected success with 'ok2', got error=%v content=%q",
+			results[2].Output.IsError, results[2].Output.Content)
+	}
+}

--- a/internal/agent/guards.go
+++ b/internal/agent/guards.go
@@ -1,0 +1,77 @@
+package agent
+
+import (
+	"encoding/json"
+
+	"github.com/flemzord/sclaw/internal/provider"
+)
+
+// loopDetector tracks repeated identical tool calls to detect stuck loops.
+type loopDetector struct {
+	threshold int
+	counts    map[string]int
+}
+
+func newLoopDetector(threshold int) *loopDetector {
+	return &loopDetector{
+		threshold: threshold,
+		counts:    make(map[string]int),
+	}
+}
+
+// normalizeArgs returns a canonical JSON representation of args so that
+// semantically identical payloads with different key ordering produce the
+// same string (e.g. {"a":1,"b":2} and {"b":2,"a":1}).
+func normalizeArgs(args json.RawMessage) string {
+	var m any
+	if err := json.Unmarshal(args, &m); err != nil {
+		// Fallback to raw bytes if the JSON is invalid.
+		return string(args)
+	}
+	normalized, err := json.Marshal(m)
+	if err != nil {
+		return string(args)
+	}
+	return string(normalized)
+}
+
+// record registers a tool call and reports whether the loop threshold
+// has been reached for this exact call signature.
+func (d *loopDetector) record(name string, args json.RawMessage) bool {
+	key := name + ":" + normalizeArgs(args)
+	d.counts[key]++
+	return d.counts[key] >= d.threshold
+}
+
+func (d *loopDetector) reset() {
+	d.counts = make(map[string]int)
+}
+
+// tokenTracker accumulates token usage and checks against a budget.
+//
+// It is not concurrent-safe by design: each instance is owned by a single
+// goroutine (the Run or RunStream loop).
+type tokenTracker struct {
+	budget int
+	usage  provider.TokenUsage
+}
+
+func newTokenTracker(budget int) *tokenTracker {
+	return &tokenTracker{budget: budget}
+}
+
+func (t *tokenTracker) add(usage provider.TokenUsage) {
+	t.usage.PromptTokens += usage.PromptTokens
+	t.usage.CompletionTokens += usage.CompletionTokens
+	t.usage.TotalTokens += usage.TotalTokens
+}
+
+// exceeded reports whether the cumulative token usage has reached the budget.
+// A zero budget means unlimited and never exceeds.
+func (t *tokenTracker) exceeded() bool {
+	return t.budget > 0 && t.usage.TotalTokens >= t.budget
+}
+
+func (t *tokenTracker) total() provider.TokenUsage {
+	return t.usage
+}

--- a/internal/agent/guards_test.go
+++ b/internal/agent/guards_test.go
@@ -1,0 +1,93 @@
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/flemzord/sclaw/internal/provider"
+)
+
+func TestLoopDetector_BelowThreshold(t *testing.T) {
+	t.Parallel()
+	d := newLoopDetector(3)
+
+	if d.record("read", json.RawMessage(`{"file":"a.txt"}`)) {
+		t.Error("expected no loop on first call")
+	}
+	if d.record("read", json.RawMessage(`{"file":"a.txt"}`)) {
+		t.Error("expected no loop on second call")
+	}
+}
+
+func TestLoopDetector_AtThreshold(t *testing.T) {
+	t.Parallel()
+	d := newLoopDetector(3)
+
+	d.record("read", json.RawMessage(`{"file":"a.txt"}`))
+	d.record("read", json.RawMessage(`{"file":"a.txt"}`))
+
+	if !d.record("read", json.RawMessage(`{"file":"a.txt"}`)) {
+		t.Error("expected loop detected at threshold")
+	}
+}
+
+func TestLoopDetector_DifferentArgs(t *testing.T) {
+	t.Parallel()
+	d := newLoopDetector(2)
+
+	d.record("read", json.RawMessage(`{"file":"a.txt"}`))
+	if d.record("read", json.RawMessage(`{"file":"b.txt"}`)) {
+		t.Error("different args should not trigger loop")
+	}
+}
+
+func TestLoopDetector_Reset(t *testing.T) {
+	t.Parallel()
+	d := newLoopDetector(2)
+
+	d.record("read", json.RawMessage(`{"file":"a.txt"}`))
+	d.reset()
+
+	if d.record("read", json.RawMessage(`{"file":"a.txt"}`)) {
+		t.Error("expected no loop after reset")
+	}
+}
+
+func TestTokenTracker_Add(t *testing.T) {
+	t.Parallel()
+	tr := newTokenTracker(1000)
+
+	tr.add(provider.TokenUsage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150})
+	tr.add(provider.TokenUsage{PromptTokens: 200, CompletionTokens: 100, TotalTokens: 300})
+
+	got := tr.total()
+	if got.PromptTokens != 300 {
+		t.Errorf("PromptTokens = %d, want 300", got.PromptTokens)
+	}
+	if got.CompletionTokens != 150 {
+		t.Errorf("CompletionTokens = %d, want 150", got.CompletionTokens)
+	}
+	if got.TotalTokens != 450 {
+		t.Errorf("TotalTokens = %d, want 450", got.TotalTokens)
+	}
+}
+
+func TestTokenTracker_Exceeded(t *testing.T) {
+	t.Parallel()
+	tr := newTokenTracker(500)
+
+	tr.add(provider.TokenUsage{TotalTokens: 500})
+	if !tr.exceeded() {
+		t.Error("expected exceeded at budget")
+	}
+}
+
+func TestTokenTracker_UnlimitedBudget(t *testing.T) {
+	t.Parallel()
+	tr := newTokenTracker(0)
+
+	tr.add(provider.TokenUsage{TotalTokens: 999999})
+	if tr.exceeded() {
+		t.Error("zero budget should never exceed")
+	}
+}

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -1,0 +1,274 @@
+package agent
+
+import (
+	"context"
+	"errors"
+
+	"github.com/flemzord/sclaw/internal/provider"
+)
+
+// Sentinel errors for agent loop termination.
+var (
+	ErrTokenBudgetExceeded  = errors.New("agent: token budget exceeded")
+	ErrMaxIterationsReached = errors.New("agent: max iterations reached")
+	ErrLoopDetected         = errors.New("agent: loop detected")
+)
+
+// Loop implements the ReAct (Reason + Act) reasoning loop.
+type Loop struct {
+	provider provider.Provider
+	executor *ToolExecutor
+	config   LoopConfig
+}
+
+// NewLoop creates a Loop with the given provider, executor, and config.
+func NewLoop(p provider.Provider, executor *ToolExecutor, cfg LoopConfig) *Loop {
+	return &Loop{
+		provider: p,
+		executor: executor,
+		config:   cfg.withDefaults(),
+	}
+}
+
+// buildInitialMessages assembles the initial message history from the request.
+func buildInitialMessages(req Request) []provider.LLMMessage {
+	var messages []provider.LLMMessage
+	if req.SystemPrompt != "" {
+		messages = append(messages, provider.LLMMessage{
+			Role:    provider.MessageRoleSystem,
+			Content: req.SystemPrompt,
+		})
+	}
+	return append(messages, req.Messages...)
+}
+
+// appendToolResults adds tool execution results to the conversation history.
+func appendToolResults(messages []provider.LLMMessage, records []ToolCallRecord) []provider.LLMMessage {
+	for _, rec := range records {
+		messages = append(messages, provider.LLMMessage{
+			Role:    provider.MessageRoleTool,
+			Content: rec.Output.Content,
+			ToolID:  rec.ID,
+		})
+	}
+	return messages
+}
+
+// Run executes the ReAct loop synchronously and returns the final response.
+//
+// A context.WithTimeout is applied using l.config.Timeout. If the caller's
+// context already carries a shorter deadline, the shorter one takes effect.
+func (l *Loop) Run(ctx context.Context, req Request) (Response, error) {
+	ctx, cancel := context.WithTimeout(ctx, l.config.Timeout)
+	defer cancel()
+
+	detector := newLoopDetector(l.config.LoopThreshold)
+	tracker := newTokenTracker(l.config.TokenBudget)
+	messages := buildInitialMessages(req)
+
+	var allToolCalls []ToolCallRecord
+
+	for i := 0; i < l.config.MaxIterations; i++ {
+		// Check context cancellation (timeout or external cancel).
+		if err := ctx.Err(); err != nil {
+			return Response{
+				ToolCalls:  allToolCalls,
+				TotalUsage: tracker.total(),
+				Iterations: i,
+				StopReason: StopReasonTimeout,
+			}, context.DeadlineExceeded
+		}
+
+		// Check token budget.
+		if tracker.exceeded() {
+			return Response{
+				ToolCalls:  allToolCalls,
+				TotalUsage: tracker.total(),
+				Iterations: i,
+				StopReason: StopReasonTokenBudget,
+			}, ErrTokenBudgetExceeded
+		}
+
+		// Call provider.
+		resp, err := l.provider.Complete(ctx, provider.CompletionRequest{
+			Messages: messages,
+			Tools:    req.Tools,
+		})
+		if err != nil {
+			return Response{
+				ToolCalls:  allToolCalls,
+				TotalUsage: tracker.total(),
+				Iterations: i,
+				StopReason: StopReasonError,
+			}, err
+		}
+
+		tracker.add(resp.Usage)
+
+		// No tool calls → the model is done reasoning.
+		if len(resp.ToolCalls) == 0 {
+			return Response{
+				Content:    resp.Content,
+				ToolCalls:  allToolCalls,
+				TotalUsage: tracker.total(),
+				Iterations: i + 1,
+				StopReason: StopReasonComplete,
+			}, nil
+		}
+
+		// Check for loops before appending assistant message to avoid
+		// leaving an orphan assistant message without tool results.
+		for _, tc := range resp.ToolCalls {
+			if detector.record(tc.Name, tc.Arguments) {
+				return Response{
+					ToolCalls:  allToolCalls,
+					TotalUsage: tracker.total(),
+					Iterations: i + 1,
+					StopReason: StopReasonLoopDetected,
+				}, ErrLoopDetected
+			}
+		}
+
+		// Append assistant message with the content (may be empty).
+		messages = append(messages, provider.LLMMessage{
+			Role:    provider.MessageRoleAssistant,
+			Content: resp.Content,
+		})
+
+		// Execute tools in parallel.
+		records := l.executor.Execute(ctx, resp.ToolCalls)
+		allToolCalls = append(allToolCalls, records...)
+
+		// Re-inject tool results into conversation.
+		messages = appendToolResults(messages, records)
+	}
+
+	// Max iterations reached.
+	return Response{
+		ToolCalls:  allToolCalls,
+		TotalUsage: tracker.total(),
+		Iterations: l.config.MaxIterations,
+		StopReason: StopReasonMaxIterations,
+	}, ErrMaxIterationsReached
+}
+
+// RunStream executes the ReAct loop and streams events over a channel.
+//
+// A context.WithTimeout is applied using l.config.Timeout. If the caller's
+// context already carries a shorter deadline, the shorter one takes effect.
+func (l *Loop) RunStream(ctx context.Context, req Request) (<-chan StreamEvent, error) {
+	ch := make(chan StreamEvent, 16)
+
+	go func() {
+		defer close(ch)
+
+		ctx, cancel := context.WithTimeout(ctx, l.config.Timeout)
+		defer cancel()
+
+		detector := newLoopDetector(l.config.LoopThreshold)
+		tracker := newTokenTracker(l.config.TokenBudget)
+		messages := buildInitialMessages(req)
+
+		for i := 0; i < l.config.MaxIterations; i++ {
+			if ctx.Err() != nil {
+				ch <- StreamEvent{Type: StreamEventError, Err: context.DeadlineExceeded}
+				return
+			}
+
+			if tracker.exceeded() {
+				ch <- StreamEvent{Type: StreamEventError, Err: ErrTokenBudgetExceeded}
+				return
+			}
+
+			streamCh, err := l.provider.Stream(ctx, provider.CompletionRequest{
+				Messages: messages,
+				Tools:    req.Tools,
+			})
+			if err != nil {
+				ch <- StreamEvent{Type: StreamEventError, Err: err}
+				return
+			}
+
+			// Consume stream, forwarding text chunks and accumulating tool calls.
+			var content string
+			var toolCalls []provider.ToolCall
+			var usage *provider.TokenUsage
+
+			var streamErr error
+			for chunk := range streamCh {
+				if chunk.Err != nil {
+					streamErr = chunk.Err
+					break
+				}
+				if chunk.Content != "" {
+					content += chunk.Content
+					ch <- StreamEvent{Type: StreamEventText, Content: chunk.Content}
+				}
+				if len(chunk.ToolCalls) > 0 {
+					toolCalls = append(toolCalls, chunk.ToolCalls...)
+				}
+				if chunk.Usage != nil {
+					usage = chunk.Usage
+				}
+			}
+
+			// Drain remaining chunks to prevent provider goroutine leak.
+			if streamErr != nil {
+				//nolint:revive // intentional empty drain loop
+				for range streamCh { //nolint:revive
+				}
+				ch <- StreamEvent{Type: StreamEventError, Err: streamErr}
+				return
+			}
+
+			if usage != nil {
+				tracker.add(*usage)
+				ch <- StreamEvent{Type: StreamEventUsage, Usage: usage}
+			}
+
+			// No tool calls → done.
+			if len(toolCalls) == 0 {
+				ch <- StreamEvent{Type: StreamEventDone}
+				return
+			}
+
+			// Check loops before appending assistant message to avoid
+			// leaving an orphan assistant message without tool results.
+			for _, tc := range toolCalls {
+				if detector.record(tc.Name, tc.Arguments) {
+					ch <- StreamEvent{Type: StreamEventError, Err: ErrLoopDetected}
+					return
+				}
+			}
+
+			messages = append(messages, provider.LLMMessage{
+				Role:    provider.MessageRoleAssistant,
+				Content: content,
+			})
+
+			// Signal tool starts.
+			for _, tc := range toolCalls {
+				ch <- StreamEvent{
+					Type:     StreamEventToolStart,
+					ToolCall: &ToolCallRecord{ID: tc.ID, Name: tc.Name, Arguments: tc.Arguments},
+				}
+			}
+
+			records := l.executor.Execute(ctx, toolCalls)
+
+			for idx := range records {
+				ch <- StreamEvent{
+					Type:     StreamEventToolEnd,
+					ToolCall: &records[idx],
+				}
+			}
+
+			// Re-inject tool results.
+			messages = appendToolResults(messages, records)
+		}
+
+		ch <- StreamEvent{Type: StreamEventError, Err: ErrMaxIterationsReached}
+	}()
+
+	return ch, nil
+}

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -1,0 +1,711 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/flemzord/sclaw/internal/provider"
+	"github.com/flemzord/sclaw/internal/tool"
+)
+
+// mockProvider returns pre-configured responses in sequence.
+type mockProvider struct {
+	mu        sync.Mutex
+	responses []provider.CompletionResponse
+	streams   [][]provider.StreamChunk
+	callIdx   int
+	streamIdx int
+}
+
+func (m *mockProvider) Complete(_ context.Context, _ provider.CompletionRequest) (provider.CompletionResponse, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.callIdx >= len(m.responses) {
+		return provider.CompletionResponse{}, fmt.Errorf("no more mock responses")
+	}
+	resp := m.responses[m.callIdx]
+	m.callIdx++
+	return resp, nil
+}
+
+func (m *mockProvider) Stream(_ context.Context, _ provider.CompletionRequest) (<-chan provider.StreamChunk, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.streamIdx >= len(m.streams) {
+		return nil, fmt.Errorf("no more mock streams")
+	}
+	chunks := m.streams[m.streamIdx]
+	m.streamIdx++
+	ch := make(chan provider.StreamChunk, len(chunks))
+	for _, c := range chunks {
+		ch <- c
+	}
+	close(ch)
+	return ch, nil
+}
+
+func (m *mockProvider) ContextWindowSize() int { return 128000 }
+func (m *mockProvider) ModelName() string      { return "mock-model" }
+
+func newLoopTestExecutor(tools ...*mockTool) *ToolExecutor {
+	reg := tool.NewRegistry()
+	for _, t := range tools {
+		if err := reg.Register(t); err != nil {
+			panic(err)
+		}
+	}
+	return newTestExecutor(reg)
+}
+
+func newTestLoop(p provider.Provider, executor *ToolExecutor, cfg LoopConfig) *Loop {
+	return NewLoop(p, executor, cfg)
+}
+
+func userMsg(content string) provider.LLMMessage {
+	return provider.LLMMessage{Role: provider.MessageRoleUser, Content: content}
+}
+
+// TestRun_TextResponse: provider returns text, no tool calls → StopReasonComplete.
+func TestRun_TextResponse(t *testing.T) {
+	t.Parallel()
+
+	p := &mockProvider{
+		responses: []provider.CompletionResponse{
+			{Content: "hello world", FinishReason: provider.FinishReasonStop},
+		},
+	}
+	executor := newLoopTestExecutor()
+	loop := newTestLoop(p, executor, LoopConfig{MaxIterations: 5})
+
+	resp, err := loop.Run(context.Background(), Request{
+		Messages: []provider.LLMMessage{userMsg("hi")},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StopReason != StopReasonComplete {
+		t.Errorf("expected StopReasonComplete, got %s", resp.StopReason)
+	}
+	if resp.Content != "hello world" {
+		t.Errorf("expected content 'hello world', got %q", resp.Content)
+	}
+	if resp.Iterations != 1 {
+		t.Errorf("expected 1 iteration, got %d", resp.Iterations)
+	}
+}
+
+// TestRun_ToolExecution: provider calls tool → result reinjected → provider returns text.
+func TestRun_ToolExecution(t *testing.T) {
+	t.Parallel()
+
+	readTool := &mockTool{
+		name:   "read",
+		output: tool.Output{Content: "file content"},
+	}
+	p := &mockProvider{
+		responses: []provider.CompletionResponse{
+			{
+				ToolCalls:    []provider.ToolCall{{ID: "1", Name: "read", Arguments: json.RawMessage(`{}`)}},
+				FinishReason: provider.FinishReasonToolUse,
+				Usage:        provider.TokenUsage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15},
+			},
+			{
+				Content:      "done",
+				FinishReason: provider.FinishReasonStop,
+				Usage:        provider.TokenUsage{PromptTokens: 20, CompletionTokens: 10, TotalTokens: 30},
+			},
+		},
+	}
+	executor := newLoopTestExecutor(readTool)
+	loop := newTestLoop(p, executor, LoopConfig{MaxIterations: 5})
+
+	resp, err := loop.Run(context.Background(), Request{
+		Messages: []provider.LLMMessage{userMsg("read a file")},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StopReason != StopReasonComplete {
+		t.Errorf("expected StopReasonComplete, got %s", resp.StopReason)
+	}
+	if resp.Iterations != 2 {
+		t.Errorf("expected 2 iterations, got %d", resp.Iterations)
+	}
+	if len(resp.ToolCalls) != 1 {
+		t.Errorf("expected 1 tool call, got %d", len(resp.ToolCalls))
+	}
+	if resp.TotalUsage.TotalTokens != 45 {
+		t.Errorf("expected total tokens 45, got %d", resp.TotalUsage.TotalTokens)
+	}
+}
+
+// TestRun_ParallelToolCalls: provider requests 3 tools at once → all results reinjected.
+func TestRun_ParallelToolCalls(t *testing.T) {
+	t.Parallel()
+
+	tool1 := &mockTool{name: "tool1", output: tool.Output{Content: "result1"}}
+	tool2 := &mockTool{name: "tool2", output: tool.Output{Content: "result2"}}
+	tool3 := &mockTool{name: "tool3", output: tool.Output{Content: "result3"}}
+
+	p := &mockProvider{
+		responses: []provider.CompletionResponse{
+			{
+				ToolCalls: []provider.ToolCall{
+					{ID: "1", Name: "tool1", Arguments: json.RawMessage(`{}`)},
+					{ID: "2", Name: "tool2", Arguments: json.RawMessage(`{}`)},
+					{ID: "3", Name: "tool3", Arguments: json.RawMessage(`{}`)},
+				},
+				FinishReason: provider.FinishReasonToolUse,
+			},
+			{Content: "all done", FinishReason: provider.FinishReasonStop},
+		},
+	}
+	executor := newLoopTestExecutor(tool1, tool2, tool3)
+	loop := newTestLoop(p, executor, LoopConfig{MaxIterations: 5})
+
+	resp, err := loop.Run(context.Background(), Request{
+		Messages: []provider.LLMMessage{userMsg("run all tools")},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StopReason != StopReasonComplete {
+		t.Errorf("expected StopReasonComplete, got %s", resp.StopReason)
+	}
+	if len(resp.ToolCalls) != 3 {
+		t.Errorf("expected 3 tool calls, got %d", len(resp.ToolCalls))
+	}
+}
+
+// TestRun_ToolError: tool returns IsError output → LLM gets error, continues.
+func TestRun_ToolError(t *testing.T) {
+	t.Parallel()
+
+	errTool := &mockTool{
+		name:   "failing_tool",
+		output: tool.Output{Content: "something went wrong", IsError: true},
+	}
+	p := &mockProvider{
+		responses: []provider.CompletionResponse{
+			{
+				ToolCalls:    []provider.ToolCall{{ID: "1", Name: "failing_tool", Arguments: json.RawMessage(`{}`)}},
+				FinishReason: provider.FinishReasonToolUse,
+			},
+			{Content: "I see the error", FinishReason: provider.FinishReasonStop},
+		},
+	}
+	executor := newLoopTestExecutor(errTool)
+	loop := newTestLoop(p, executor, LoopConfig{MaxIterations: 5})
+
+	resp, err := loop.Run(context.Background(), Request{
+		Messages: []provider.LLMMessage{userMsg("do something")},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StopReason != StopReasonComplete {
+		t.Errorf("expected StopReasonComplete, got %s", resp.StopReason)
+	}
+	if len(resp.ToolCalls) != 1 {
+		t.Errorf("expected 1 tool call, got %d", len(resp.ToolCalls))
+	}
+	if !resp.ToolCalls[0].Output.IsError {
+		t.Error("expected tool call output to be an error")
+	}
+}
+
+// TestRun_ParallelToolErrorIsolation: one tool errors in parallel, others succeed.
+func TestRun_ParallelToolErrorIsolation(t *testing.T) {
+	t.Parallel()
+
+	goodTool := &mockTool{name: "good", output: tool.Output{Content: "ok"}}
+	badTool := &mockTool{name: "bad", panicMsg: "boom"}
+
+	p := &mockProvider{
+		responses: []provider.CompletionResponse{
+			{
+				ToolCalls: []provider.ToolCall{
+					{ID: "1", Name: "good", Arguments: json.RawMessage(`{}`)},
+					{ID: "2", Name: "bad", Arguments: json.RawMessage(`{}`)},
+				},
+				FinishReason: provider.FinishReasonToolUse,
+			},
+			{Content: "handled", FinishReason: provider.FinishReasonStop},
+		},
+	}
+	executor := newLoopTestExecutor(goodTool, badTool)
+	loop := newTestLoop(p, executor, LoopConfig{MaxIterations: 5})
+
+	resp, err := loop.Run(context.Background(), Request{
+		Messages: []provider.LLMMessage{userMsg("parallel")},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StopReason != StopReasonComplete {
+		t.Errorf("expected StopReasonComplete, got %s", resp.StopReason)
+	}
+	if len(resp.ToolCalls) != 2 {
+		t.Fatalf("expected 2 tool calls, got %d", len(resp.ToolCalls))
+	}
+	if resp.ToolCalls[0].Output.IsError {
+		t.Error("expected first tool call to succeed")
+	}
+	if !resp.ToolCalls[1].Panicked || !resp.ToolCalls[1].Output.IsError {
+		t.Error("expected second tool call to be a panicked error")
+	}
+}
+
+// TestRun_MaxIterations: MaxIterations=2, provider always returns tool calls → StopReasonMaxIterations.
+func TestRun_MaxIterations(t *testing.T) {
+	t.Parallel()
+
+	loopTool := &mockTool{name: "loop_tool", output: tool.Output{Content: "ok"}}
+	// Provide more responses than MaxIterations to ensure the loop hits the limit.
+	p := &mockProvider{
+		responses: []provider.CompletionResponse{
+			{ToolCalls: []provider.ToolCall{{ID: "1", Name: "loop_tool", Arguments: json.RawMessage(`{"i":1}`)}}, FinishReason: provider.FinishReasonToolUse},
+			{ToolCalls: []provider.ToolCall{{ID: "2", Name: "loop_tool", Arguments: json.RawMessage(`{"i":2}`)}}, FinishReason: provider.FinishReasonToolUse},
+			{ToolCalls: []provider.ToolCall{{ID: "3", Name: "loop_tool", Arguments: json.RawMessage(`{"i":3}`)}}, FinishReason: provider.FinishReasonToolUse},
+		},
+	}
+	executor := newLoopTestExecutor(loopTool)
+	loop := newTestLoop(p, executor, LoopConfig{MaxIterations: 2, LoopThreshold: 10})
+
+	resp, err := loop.Run(context.Background(), Request{
+		Messages: []provider.LLMMessage{userMsg("loop")},
+	})
+
+	if !errors.Is(err, ErrMaxIterationsReached) {
+		t.Fatalf("expected ErrMaxIterationsReached, got %v", err)
+	}
+	if resp.StopReason != StopReasonMaxIterations {
+		t.Errorf("expected StopReasonMaxIterations, got %s", resp.StopReason)
+	}
+	if resp.Iterations != 2 {
+		t.Errorf("expected 2 iterations, got %d", resp.Iterations)
+	}
+}
+
+// TestRun_LoopDetection: same tool+args repeated LoopThreshold times → StopReasonLoopDetected.
+func TestRun_LoopDetection(t *testing.T) {
+	t.Parallel()
+
+	loopTool := &mockTool{name: "repeat_tool", output: tool.Output{Content: "same"}}
+	sameArgs := json.RawMessage(`{"key":"value"}`)
+	p := &mockProvider{
+		responses: []provider.CompletionResponse{
+			{ToolCalls: []provider.ToolCall{{ID: "1", Name: "repeat_tool", Arguments: sameArgs}}, FinishReason: provider.FinishReasonToolUse},
+			{ToolCalls: []provider.ToolCall{{ID: "2", Name: "repeat_tool", Arguments: sameArgs}}, FinishReason: provider.FinishReasonToolUse},
+			{ToolCalls: []provider.ToolCall{{ID: "3", Name: "repeat_tool", Arguments: sameArgs}}, FinishReason: provider.FinishReasonToolUse},
+			{ToolCalls: []provider.ToolCall{{ID: "4", Name: "repeat_tool", Arguments: sameArgs}}, FinishReason: provider.FinishReasonToolUse},
+		},
+	}
+	executor := newLoopTestExecutor(loopTool)
+	loop := newTestLoop(p, executor, LoopConfig{MaxIterations: 10, LoopThreshold: 3})
+
+	resp, err := loop.Run(context.Background(), Request{
+		Messages: []provider.LLMMessage{userMsg("repeat")},
+	})
+
+	if !errors.Is(err, ErrLoopDetected) {
+		t.Fatalf("expected ErrLoopDetected, got %v", err)
+	}
+	if resp.StopReason != StopReasonLoopDetected {
+		t.Errorf("expected StopReasonLoopDetected, got %s", resp.StopReason)
+	}
+}
+
+// TestRun_TokenBudget: TokenBudget=100, provider returns Usage{TotalTokens:150} → StopReasonTokenBudget on next iteration.
+func TestRun_TokenBudget(t *testing.T) {
+	t.Parallel()
+
+	readTool := &mockTool{name: "read", output: tool.Output{Content: "data"}}
+	p := &mockProvider{
+		responses: []provider.CompletionResponse{
+			{
+				ToolCalls:    []provider.ToolCall{{ID: "1", Name: "read", Arguments: json.RawMessage(`{}`)}},
+				FinishReason: provider.FinishReasonToolUse,
+				Usage:        provider.TokenUsage{PromptTokens: 50, CompletionTokens: 100, TotalTokens: 150},
+			},
+			// This second response should never be reached because budget exceeded.
+			{Content: "should not reach", FinishReason: provider.FinishReasonStop},
+		},
+	}
+	executor := newLoopTestExecutor(readTool)
+	loop := newTestLoop(p, executor, LoopConfig{MaxIterations: 10, TokenBudget: 100})
+
+	resp, err := loop.Run(context.Background(), Request{
+		Messages: []provider.LLMMessage{userMsg("use tokens")},
+	})
+
+	if !errors.Is(err, ErrTokenBudgetExceeded) {
+		t.Fatalf("expected ErrTokenBudgetExceeded, got %v", err)
+	}
+	if resp.StopReason != StopReasonTokenBudget {
+		t.Errorf("expected StopReasonTokenBudget, got %s", resp.StopReason)
+	}
+}
+
+// TestRun_Timeout: use a context that's already cancelled → StopReasonTimeout.
+func TestRun_Timeout(t *testing.T) {
+	t.Parallel()
+
+	p := &mockProvider{
+		responses: []provider.CompletionResponse{
+			{Content: "should not reach", FinishReason: provider.FinishReasonStop},
+		},
+	}
+	executor := newLoopTestExecutor()
+	loop := newTestLoop(p, executor, LoopConfig{MaxIterations: 5})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	resp, err := loop.Run(ctx, Request{
+		Messages: []provider.LLMMessage{userMsg("hello")},
+	})
+
+	if err == nil {
+		t.Fatal("expected an error for cancelled context")
+	}
+	if resp.StopReason != StopReasonTimeout {
+		t.Errorf("expected StopReasonTimeout, got %s", resp.StopReason)
+	}
+}
+
+// TestRun_PanicRecovery: tool panics → error result, loop continues.
+func TestRun_PanicRecovery(t *testing.T) {
+	t.Parallel()
+
+	panicTool := &mockTool{name: "panic_tool", panicMsg: "unexpected panic"}
+	p := &mockProvider{
+		responses: []provider.CompletionResponse{
+			{
+				ToolCalls:    []provider.ToolCall{{ID: "1", Name: "panic_tool", Arguments: json.RawMessage(`{}`)}},
+				FinishReason: provider.FinishReasonToolUse,
+			},
+			{Content: "recovered", FinishReason: provider.FinishReasonStop},
+		},
+	}
+	executor := newLoopTestExecutor(panicTool)
+	loop := newTestLoop(p, executor, LoopConfig{MaxIterations: 5})
+
+	resp, err := loop.Run(context.Background(), Request{
+		Messages: []provider.LLMMessage{userMsg("panic please")},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StopReason != StopReasonComplete {
+		t.Errorf("expected StopReasonComplete, got %s", resp.StopReason)
+	}
+	if len(resp.ToolCalls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(resp.ToolCalls))
+	}
+	if !resp.ToolCalls[0].Panicked {
+		t.Error("expected tool call to be marked as panicked")
+	}
+	if !resp.ToolCalls[0].Output.IsError {
+		t.Error("expected panicked tool output to be an error")
+	}
+}
+
+// --- Streaming tests ---
+
+// TestRunStream_TextChunks: stream returns text chunks → StreamEventText events + StreamEventDone.
+func TestRunStream_TextChunks(t *testing.T) {
+	t.Parallel()
+
+	p := &mockProvider{
+		streams: [][]provider.StreamChunk{
+			{
+				{Content: "hello "},
+				{Content: "world"},
+				{FinishReason: provider.FinishReasonStop},
+			},
+		},
+	}
+	executor := newLoopTestExecutor()
+	loop := newTestLoop(p, executor, LoopConfig{MaxIterations: 5})
+
+	ch, err := loop.RunStream(context.Background(), Request{
+		Messages: []provider.LLMMessage{userMsg("stream text")},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var textContent string
+	var gotDone bool
+	for e := range ch {
+		if e.Type == StreamEventText {
+			textContent += e.Content
+		}
+		if e.Type == StreamEventDone {
+			gotDone = true
+		}
+		if e.Type == StreamEventError {
+			t.Fatalf("unexpected error event: %v", e.Err)
+		}
+	}
+
+	if textContent != "hello world" {
+		t.Errorf("expected text 'hello world', got %q", textContent)
+	}
+	if !gotDone {
+		t.Error("expected StreamEventDone")
+	}
+}
+
+// TestRunStream_ToolExecution: stream with tool calls → tool start/end events → final done.
+func TestRunStream_ToolExecution(t *testing.T) {
+	t.Parallel()
+
+	readTool := &mockTool{name: "read", output: tool.Output{Content: "file data"}}
+	p := &mockProvider{
+		streams: [][]provider.StreamChunk{
+			{
+				{ToolCalls: []provider.ToolCall{{ID: "1", Name: "read", Arguments: json.RawMessage(`{}`)}}},
+				{FinishReason: provider.FinishReasonToolUse},
+			},
+			{
+				{Content: "got it"},
+				{FinishReason: provider.FinishReasonStop},
+			},
+		},
+	}
+	executor := newLoopTestExecutor(readTool)
+	loop := newTestLoop(p, executor, LoopConfig{MaxIterations: 5})
+
+	ch, err := loop.RunStream(context.Background(), Request{
+		Messages: []provider.LLMMessage{userMsg("read file")},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var toolStarts, toolEnds int
+	var gotDone bool
+	for e := range ch {
+		switch e.Type {
+		case StreamEventToolStart:
+			toolStarts++
+		case StreamEventToolEnd:
+			toolEnds++
+		case StreamEventDone:
+			gotDone = true
+		case StreamEventError:
+			t.Fatalf("unexpected error event: %v", e.Err)
+		}
+	}
+
+	if toolStarts != 1 {
+		t.Errorf("expected 1 tool start, got %d", toolStarts)
+	}
+	if toolEnds != 1 {
+		t.Errorf("expected 1 tool end, got %d", toolEnds)
+	}
+	if !gotDone {
+		t.Error("expected StreamEventDone")
+	}
+}
+
+// TestRunStream_Done: simple stream completion with no tools.
+func TestRunStream_Done(t *testing.T) {
+	t.Parallel()
+
+	p := &mockProvider{
+		streams: [][]provider.StreamChunk{
+			{
+				{Content: "simple response"},
+				{FinishReason: provider.FinishReasonStop},
+			},
+		},
+	}
+	executor := newLoopTestExecutor()
+	loop := newTestLoop(p, executor, LoopConfig{MaxIterations: 5, Timeout: 10 * time.Second})
+
+	ch, err := loop.RunStream(context.Background(), Request{
+		Messages: []provider.LLMMessage{userMsg("simple")},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var gotDone bool
+	for e := range ch {
+		if e.Type == StreamEventDone {
+			gotDone = true
+		}
+		if e.Type == StreamEventError {
+			t.Fatalf("unexpected error event: %v", e.Err)
+		}
+	}
+
+	if !gotDone {
+		t.Error("expected StreamEventDone")
+	}
+}
+
+// TestRunStream_MaxIterations: streaming with max iterations guard.
+func TestRunStream_MaxIterations(t *testing.T) {
+	t.Parallel()
+
+	readTool := &mockTool{name: "read", output: tool.Output{Content: "data"}}
+	p := &mockProvider{
+		streams: [][]provider.StreamChunk{
+			{
+				{ToolCalls: []provider.ToolCall{{ID: "1", Name: "read", Arguments: json.RawMessage(`{"i":1}`)}}},
+				{FinishReason: provider.FinishReasonToolUse},
+			},
+			{
+				{ToolCalls: []provider.ToolCall{{ID: "2", Name: "read", Arguments: json.RawMessage(`{"i":2}`)}}},
+				{FinishReason: provider.FinishReasonToolUse},
+			},
+		},
+	}
+	executor := newLoopTestExecutor(readTool)
+	loop := newTestLoop(p, executor, LoopConfig{MaxIterations: 1, LoopThreshold: 10})
+
+	ch, err := loop.RunStream(context.Background(), Request{
+		Messages: []provider.LLMMessage{userMsg("stream loop")},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var gotMaxIter bool
+	for e := range ch {
+		if e.Type == StreamEventError && errors.Is(e.Err, ErrMaxIterationsReached) {
+			gotMaxIter = true
+		}
+	}
+	if !gotMaxIter {
+		t.Error("expected StreamEventError with ErrMaxIterationsReached")
+	}
+}
+
+// TestRunStream_TokenBudget: streaming with token budget guard.
+func TestRunStream_TokenBudget(t *testing.T) {
+	t.Parallel()
+
+	readTool := &mockTool{name: "read", output: tool.Output{Content: "data"}}
+	p := &mockProvider{
+		streams: [][]provider.StreamChunk{
+			{
+				{ToolCalls: []provider.ToolCall{{ID: "1", Name: "read", Arguments: json.RawMessage(`{}`)}}},
+				{Usage: &provider.TokenUsage{PromptTokens: 50, CompletionTokens: 100, TotalTokens: 150}},
+				{FinishReason: provider.FinishReasonToolUse},
+			},
+			// Should not be reached.
+			{
+				{Content: "unreachable"},
+				{FinishReason: provider.FinishReasonStop},
+			},
+		},
+	}
+	executor := newLoopTestExecutor(readTool)
+	loop := newTestLoop(p, executor, LoopConfig{MaxIterations: 10, TokenBudget: 100})
+
+	ch, err := loop.RunStream(context.Background(), Request{
+		Messages: []provider.LLMMessage{userMsg("use tokens")},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var gotBudget bool
+	for e := range ch {
+		if e.Type == StreamEventError && errors.Is(e.Err, ErrTokenBudgetExceeded) {
+			gotBudget = true
+		}
+	}
+	if !gotBudget {
+		t.Error("expected StreamEventError with ErrTokenBudgetExceeded")
+	}
+}
+
+// TestRunStream_LoopDetection: streaming with loop detection guard.
+func TestRunStream_LoopDetection(t *testing.T) {
+	t.Parallel()
+
+	readTool := &mockTool{name: "repeat", output: tool.Output{Content: "same"}}
+	sameArgs := json.RawMessage(`{"key":"value"}`)
+	p := &mockProvider{
+		streams: [][]provider.StreamChunk{
+			{
+				{ToolCalls: []provider.ToolCall{{ID: "1", Name: "repeat", Arguments: sameArgs}}},
+				{FinishReason: provider.FinishReasonToolUse},
+			},
+			{
+				{ToolCalls: []provider.ToolCall{{ID: "2", Name: "repeat", Arguments: sameArgs}}},
+				{FinishReason: provider.FinishReasonToolUse},
+			},
+			{
+				{ToolCalls: []provider.ToolCall{{ID: "3", Name: "repeat", Arguments: sameArgs}}},
+				{FinishReason: provider.FinishReasonToolUse},
+			},
+		},
+	}
+	executor := newLoopTestExecutor(readTool)
+	loop := newTestLoop(p, executor, LoopConfig{MaxIterations: 10, LoopThreshold: 3})
+
+	ch, err := loop.RunStream(context.Background(), Request{
+		Messages: []provider.LLMMessage{userMsg("repeat")},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var gotLoop bool
+	for e := range ch {
+		if e.Type == StreamEventError && errors.Is(e.Err, ErrLoopDetected) {
+			gotLoop = true
+		}
+	}
+	if !gotLoop {
+		t.Error("expected StreamEventError with ErrLoopDetected")
+	}
+}
+
+// TestRunStream_Timeout: streaming with cancelled context.
+func TestRunStream_Timeout(t *testing.T) {
+	t.Parallel()
+
+	p := &mockProvider{
+		streams: [][]provider.StreamChunk{
+			{
+				{Content: "should not reach"},
+				{FinishReason: provider.FinishReasonStop},
+			},
+		},
+	}
+	executor := newLoopTestExecutor()
+	loop := newTestLoop(p, executor, LoopConfig{MaxIterations: 5})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	ch, err := loop.RunStream(ctx, Request{
+		Messages: []provider.LLMMessage{userMsg("timeout")},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var gotTimeout bool
+	for e := range ch {
+		if e.Type == StreamEventError {
+			gotTimeout = true
+		}
+	}
+	if !gotTimeout {
+		t.Error("expected StreamEventError for cancelled context")
+	}
+}

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -1,0 +1,74 @@
+// Package agent implements the ReAct (Reason + Act) reasoning loop
+// that transforms user messages into responses through iterative
+// provider calls and tool executions.
+package agent
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/flemzord/sclaw/internal/provider"
+	"github.com/flemzord/sclaw/internal/tool"
+)
+
+// StopReason describes why the agent loop terminated.
+type StopReason string
+
+// StopReason constants for agent loop termination.
+const (
+	StopReasonComplete      StopReason = "complete"
+	StopReasonMaxIterations StopReason = "max_iterations"
+	StopReasonLoopDetected  StopReason = "loop_detected"
+	StopReasonTokenBudget   StopReason = "token_budget"
+	StopReasonTimeout       StopReason = "timeout"
+	StopReasonError         StopReason = "error"
+)
+
+// ToolCallRecord tracks one tool invocation during the agent loop.
+type ToolCallRecord struct {
+	ID        string
+	Name      string
+	Arguments json.RawMessage
+	Output    tool.Output
+	Duration  time.Duration
+	Panicked  bool
+}
+
+// StreamEventType identifies the kind of streaming event.
+type StreamEventType string
+
+// StreamEventType constants for streaming events.
+const (
+	StreamEventText      StreamEventType = "text"
+	StreamEventToolStart StreamEventType = "tool_start"
+	StreamEventToolEnd   StreamEventType = "tool_end"
+	StreamEventDone      StreamEventType = "done"
+	StreamEventError     StreamEventType = "error"
+	StreamEventUsage     StreamEventType = "usage"
+)
+
+// StreamEvent is a single event emitted during a streaming agent loop.
+type StreamEvent struct {
+	Type     StreamEventType
+	Content  string
+	ToolCall *ToolCallRecord
+	Usage    *provider.TokenUsage
+	Err      error
+}
+
+// Request is the input to the agent loop.
+type Request struct {
+	Messages     []provider.LLMMessage
+	SystemPrompt string
+	Tools        []provider.ToolDefinition
+	Config       LoopConfig
+}
+
+// Response is the output of the agent loop.
+type Response struct {
+	Content    string
+	ToolCalls  []ToolCallRecord
+	TotalUsage provider.TokenUsage
+	Iterations int
+	StopReason StopReason
+}


### PR DESCRIPTION
## Summary

Implements the ReAct (Reason + Act) reasoning loop as specified in #6. The agent loop transforms user messages into responses through iterative provider calls and tool executions.

### New files

- `internal/agent/loop.go` — `Loop.Run()` (synchronous) and `Loop.RunStream()` (streaming via channel)
- `internal/agent/config.go` — `LoopConfig` with defaults (max iterations: 10, timeout: 5min, loop threshold: 3)
- `internal/agent/guards.go` — `loopDetector` (repeated call detection with JSON key normalization) and `tokenTracker`
- `internal/agent/executor.go` — `ToolExecutor` with parallel execution (`sync.WaitGroup`) and panic recovery (`defer recover()`)
- `internal/agent/types.go` — `Request`, `Response`, `ToolCallRecord`, `StreamEvent`, `StopReason`

### Guardrails implemented

- **Max iterations** — configurable limit (default 10), returns `ErrMaxIterationsReached`
- **Loop detection** — detects repeated identical tool calls (same name + normalized JSON args), returns `ErrLoopDetected`
- **Token budget** — cumulative input+output tracking, returns `ErrTokenBudgetExceeded`
- **Timeout** — `context.WithTimeout`, returns `context.DeadlineExceeded`

### Key design decisions

- Loop detection normalizes JSON arguments via unmarshal/remarshal to handle different key orderings
- Loop check runs **before** appending assistant message to avoid orphan messages without tool results (which strict providers reject)
- Stream error handling drains the provider channel to prevent goroutine leaks
- Common logic (`buildInitialMessages`, `appendToolResults`) extracted to reduce duplication between `Run` and `RunStream`
- `StreamEventUsage` type added for usage events (distinct from `StreamEventText`)

### Test coverage

| Validation criterion | Test |
|---|---|
| Text response (no tools) | `TestRun_TextResponse` |
| Tool execution + reinjection | `TestRun_ToolExecution` |
| Parallel tool calls | `TestRun_ParallelToolCalls`, `TestExecute_ParallelExecution` |
| Parallel error isolation | `TestRun_ParallelToolErrorIsolation`, `TestExecute_ParallelErrorIsolation` |
| Error result to LLM | `TestRun_ToolError` |
| Max iterations | `TestRun_MaxIterations`, `TestRunStream_MaxIterations` |
| Loop detection | `TestRun_LoopDetection`, `TestRunStream_LoopDetection` |
| Token budget | `TestRun_TokenBudget`, `TestRunStream_TokenBudget` |
| Timeout | `TestRun_Timeout`, `TestRunStream_Timeout` |
| Streaming chunks | `TestRunStream_TextChunks`, `TestRunStream_Done` |
| Panic recovery | `TestRun_PanicRecovery`, `TestExecute_PanicRecovery` |
| E2E mock provider+tools | `TestRun_ToolExecution`, `TestRunStream_ToolExecution` |

All tests pass with `-race` flag.

Closes #6

## Test plan

- [x] `go test -race -count=1 ./internal/agent/` passes (1.5s)
- [x] `golangci-lint run ./internal/agent/` reports 0 issues
- [x] All 12 validation criteria from the issue have corresponding tests
- [x] Both `Run()` and `RunStream()` guard paths are tested