### PR TITLE
fix(pipeline): prevent sendError channel routing failure and duplicate subagent tool registration

### DIFF
--- a/internal/multiagent/factory.go
+++ b/internal/multiagent/factory.go
@@ -115,9 +115,13 @@ func (f *Factory) ForSession(session *router.Session, msg message.InboundMessage
 	toolReg := f.buildToolRegistry(agentCfg)
 
 	// Register sub-agent tools so the session can spawn/manage sub-agents.
+	// Skip if already registered (ForSession is called per-message and the
+	// global tool registry persists across calls).
 	if f.subAgentMgr != nil {
-		if err := subagent.RegisterTools(toolReg, f.subAgentMgr, session.AgentID, session.ID, false); err != nil {
-			return nil, fmt.Errorf("multiagent: registering subagent tools for session %s: %w", session.ID, err)
+		if _, err := toolReg.Get("sessions_list"); err != nil {
+			if err := subagent.RegisterTools(toolReg, f.subAgentMgr, session.AgentID, session.ID, false); err != nil {
+				return nil, fmt.Errorf("multiagent: registering subagent tools for session %s: %w", session.ID, err)
+			}
 		}
 	}
 

--- a/internal/router/pipeline.go
+++ b/internal/router/pipeline.go
@@ -160,6 +160,7 @@ func (p *Pipeline) Execute(ctx context.Context, env envelope) PipelineResult {
 	// session pointer (R1 fix).
 	loop, err := p.cfg.AgentFactory.ForSession(session, env.Message)
 	if err != nil {
+		logger.Error("pipeline: agent initialization failed", "error", err, "session_id", session.ID, "agent_id", session.AgentID)
 		p.sendError(ctx, env.Message, "Failed to initialize agent.")
 		return PipelineResult{Session: session, Error: err}
 	}
@@ -317,6 +318,7 @@ func (p *Pipeline) Execute(ctx context.Context, env envelope) PipelineResult {
 // sendError sends a user-friendly error message via ResponseSender. Never panics.
 func (p *Pipeline) sendError(ctx context.Context, original message.InboundMessage, text string) {
 	errMsg := message.NewTextMessage(original.Chat, text)
+	errMsg.Channel = original.Channel
 	errMsg.ThreadID = original.ThreadID
 	errMsg.ReplyToID = original.ID
 	if err := p.cfg.ResponseSender.Send(ctx, errMsg); err != nil {


### PR DESCRIPTION
## Summary
- Fix `sendError` failing to route error responses when the channel lookup returns an error
- Prevent duplicate subagent tool registration by checking if tools are already registered before re-registering on each `ForSession` call

## Test plan
- [ ] Verify error responses are correctly routed back to the originating channel
- [ ] Verify subagent tools are registered only once per session
- [ ] `go test ./internal/multiagent/... ./internal/router/...`