### PR TITLE
feat(multiagent): wire module-provided HistoryStore into agent factory

### DIFF
--- a/internal/multiagent/factory.go
+++ b/internal/multiagent/factory.go
@@ -41,6 +41,11 @@ type FactoryConfig struct {
 	// SanitizedEnv, if non-nil, provides a pre-sanitized set of environment
 	// variables passed to tools that spawn subprocesses.
 	SanitizedEnv []string
+
+	// HistoryStore, if non-nil, is used for all agents instead of
+	// opening per-agent SQLite databases. Provided by the active
+	// memory module (e.g., memory.obsidian or memory.sqlite).
+	HistoryStore memory.HistoryStore
 }
 
 // Factory resolves the agent for a session and creates an agent.Loop
@@ -205,6 +210,13 @@ func (f *Factory) ResolveHistory(agentID string) memory.HistoryStore {
 		return nil
 	}
 
+	// Use module-provided store if available.
+	if f.cfg.HistoryStore != nil {
+		f.stores[agentID] = f.cfg.HistoryStore
+		return f.cfg.HistoryStore
+	}
+
+	// Fallback: per-agent SQLite.
 	dbPath := filepath.Join(agentCfg.DataDir, "memory.db")
 	store, db, err := sqlite.OpenHistoryStore(dbPath)
 	if err != nil {

--- a/pkg/app/wire.go
+++ b/pkg/app/wire.go
@@ -9,6 +9,7 @@ import (
 	"github.com/flemzord/sclaw/internal/channel"
 	"github.com/flemzord/sclaw/internal/core"
 	"github.com/flemzord/sclaw/internal/cron"
+	"github.com/flemzord/sclaw/internal/memory"
 	"github.com/flemzord/sclaw/internal/multiagent"
 	"github.com/flemzord/sclaw/internal/provider"
 	"github.com/flemzord/sclaw/internal/router"
@@ -125,6 +126,12 @@ func wireRouter(
 		urlFilter, _ = svc.(*security.URLFilter)
 	}
 
+	// Resolve memory module's history store (if any).
+	var historyStore memory.HistoryStore
+	if svc, ok := appCtx.GetService("memory.history"); ok {
+		historyStore, _ = svc.(memory.HistoryStore)
+	}
+
 	// Build the agent factory.
 	factory := multiagent.NewFactory(multiagent.FactoryConfig{
 		Registry:        registry,
@@ -134,6 +141,7 @@ func wireRouter(
 		AuditLogger:     auditLogger,
 		RateLimiter:     rateLimiter,
 		URLFilter:       urlFilter,
+		HistoryStore:    historyStore,
 	})
 
 	// Create sub-agent manager and wire it into the factory.


### PR DESCRIPTION
## Summary
- Add `HistoryStore` field to `FactoryConfig` so memory modules (obsidian, sqlite) can inject their store via the service registry
- `ResolveHistory()` now uses the injected store when available, falling back to per-agent SQLite databases when no module is active
- `wireRouter()` resolves `memory.history` service and passes it to the factory

## Behavior

| Config | Result |
|--------|--------|
| `memory.obsidian` active | Factory uses the obsidian historyStore |
| `memory.sqlite` active | Factory uses the sqlite module historyStore |
| No memory module | Fallback to per-agent SQLite (existing behavior) |

## Test plan
- [ ] `go test ./internal/multiagent/... -run TestFactory_ResolveHistory`
- [ ] `go test ./modules/memory/obsidian/...`
- [ ] `golangci-lint run ./internal/multiagent/... ./pkg/app/...`